### PR TITLE
docs: update poetry install url

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ docker-compose down --rmi all --volumes --remove-orphans
 
 ```
 $ cd /app
-$ curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python -
+$ curl -sSL https://install.python-poetry.org | python -
 $ poetry config virtualenvs.in-project true && poetry install
 $ poetry shell
 $ pytest --cov=src --cov-branch --cov-report=term-missing -vv

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ change plugin repository url for what you want.
 
 ```
 $ cd /app/
-$ curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python -
+$ curl -sSL https://install.python-poetry.org | python -
 $ poetry config virtualenvs.in-project true && poetry install
 $ poetry shell
 # python src/main chain_name address > result.csv


### PR DESCRIPTION
poetryのインストール用URLを変更した。

URLはここで確認している。
https://python-poetry.org/docs/master/#installing-with-the-official-installer
![image](https://user-images.githubusercontent.com/15353515/164605368-c544ee5a-555a-4b61-a739-679fdea81373.png)


コマンドが動作することを確認済み。
![image](https://user-images.githubusercontent.com/15353515/164605098-31370562-871b-46f3-b980-c32439175c6d.png)
