### PR TITLE
fix: correct applicable plugin handling

### DIFF
--- a/src/senka/senka.py
+++ b/src/senka/senka.py
@@ -96,21 +96,19 @@ class Senka:
     ) -> Tuple[List[CaajJournal], List[UnknownTransaction]]:
         caaj = []
         unknown_transactions = []
-        for transaction in transactions:
-            for plugin in plugins:
-                if plugin.can_handle(transaction):
-                    caaj_peace = plugin.get_caajs(
-                        address, transaction, token_original_ids
+        for tx in transactions:
+            applicable_plugin = next(filter(lambda p: p.can_handle(tx), plugins), None)
+            if applicable_plugin:
+                caaj.extend(
+                    applicable_plugin.get_caajs(address, tx, token_original_ids)
+                )
+            else:
+                unknown_transactions.append(
+                    UnknownTransaction(
+                        chain,
+                        address,
+                        tx.transaction_id,
+                        "there is no applicable plugin",
                     )
-                    caaj.extend(caaj_peace)
-                    break
-                else:
-                    unknown_transactions.append(
-                        UnknownTransaction(
-                            chain,
-                            address,
-                            transaction.transaction_id,
-                            "there is no applicable plugin",
-                        )
-                    )
+                )
         return caaj, unknown_transactions


### PR DESCRIPTION
transactionに対してpluginを適用するロジックを修正。

ci pass
[![senka](https://github.com/kouMatsumoto/senka/actions/workflows/ci.yml/badge.svg)](https://github.com/kouMatsumoto/senka/actions/workflows/ci.yml)

#### 変更前

| 条件 | 結果 |
| --- | --- |
| chainに対応するpluginが0件の場合 | 何も結果に含めない |
| chainに対応するpluginが1件以上であり、そのうちcan_handleが0件の場合 | UnknowTransactionを生成して結果に含める |
| chainに対応するpluginが1件以上であり、そのうちcan_handleが1件以上の場合 | 最初のcan_handleを返したpluginでCaajJournalを生成して結果に含める |

#### 変更後

| 条件 | 結果 |
| --- | --- |
| chainに対応するpluginが0件の場合 | **UnknowTransactionを生成して結果に含める** |
| chainに対応するpluginが1件以上であり、そのうちcan_handleが0件の場合 | UnknowTransactionを生成して結果に含める |
| chainに対応するpluginが1件以上であり、そのうちcan_handleが1件以上の場合 | 最初のcan_handleを返したpluginでCaajJournalを生成して結果に含める |



